### PR TITLE
Update navigate url logic

### DIFF
--- a/client/spec/views/add.test.js
+++ b/client/spec/views/add.test.js
@@ -12,6 +12,9 @@ describe('view:add', function() {
         expect(addView.save).toBeDefined();
     });
 
+    //dont worry about catching the event - just test the functionality
+    //of the event handler
+
     // it('should trigger the save function on click', function() {
     //     addView.render();
     //     addView.$el.find('a.save-button').trigger('click');

--- a/client/src/controller.js
+++ b/client/src/controller.js
@@ -13,21 +13,34 @@ module.exports = Controller = Marionette.Controller.extend({
         App.core.vent.trigger('app:log', 'Controller: "Home" route hit.');
         var view = window.App.views.contactsView;
         this.renderView(view);
+        window.App.router.navigate('#');
     },
 
     details: function(id) {
         App.core.vent.trigger('app:log', 'Controller: "Contact Details" route hit.');
         var view = new ContactDetailsView({ model: window.App.data.contacts.get(id)});
         this.renderView(view);
+        window.App.router.navigate('details/' + id);
     },
 
     add: function() {
         App.core.vent.trigger('app:log', 'Controller: "Add Contact" route hit.');
         var view = new AddContactView();
         this.renderView(view);
+        window.App.router.navigate('add');
     },
 
     renderView: function(view) {
+        this.destroyCurrentView(view);
+        App.core.vent.trigger('app:log', 'Controller: Rendering new view.');
         $('#js-boilerplate-app').html(view.render().el);
+    },
+
+    destroyCurrentView: function(view) {
+        if (!_.isUndefined(window.App.views.currentView)) {
+            App.core.vent.trigger('app:log', 'Controller: Destroying existing view.');
+            window.App.views.currentView.close();
+        }
+        window.App.views.currentView = view;
     }
 });

--- a/client/src/views/add.js
+++ b/client/src/views/add.js
@@ -19,6 +19,6 @@ module.exports = AddView = Marionette.ItemView.extend({
 
         window.App.data.contacts.create(newContact);
         window.App.core.vent.trigger('app:log', 'Add View: Saved new contact!');
-        window.App.router.navigate('#', { trigger: true });
+        window.App.controller.home();
     }
 });

--- a/client/src/views/contact_details.js
+++ b/client/src/views/contact_details.js
@@ -8,6 +8,6 @@ module.exports = ContactDetailsView = Marionette.ItemView.extend({
 
     goBack: function(e) {
         e.preventDefault();
-        window.App.router.navigate('#',{trigger: true});
+        window.App.controller.home();
     }
 });

--- a/client/src/views/contacts.js
+++ b/client/src/views/contacts.js
@@ -10,7 +10,8 @@ var itemView = Marionette.ItemView.extend({
     },
 
     showDetails: function() {
-        window.App.router.navigate('details/' + this.model.id, { trigger: true });
+        window.App.core.vent.trigger('app:log', 'Contacts View: showDetails hit.');
+        window.App.controller.details(this.model.id);
     }
 });
 


### PR DESCRIPTION
Best practices state that the router should ONLY be used as a router,
and should not be used to control flow of the app from within the app.
That is what the controller is for.  This commit updates the logic to
not use the router but instead use the controller for changing screens
throughout the app when necessary.
