### PR TITLE
Gulp

### DIFF
--- a/app/routes.js
+++ b/app/routes.js
@@ -7,4 +7,5 @@ module.exports.initialize = function(app) {
     app.get('/api/contacts/:id', contacts.getById);
     app.post('/api/contacts', contacts.add);
     app.put('/api/contacts', contacts.update);
+    app.delete('/api/contacts/:id', contacts.delete);
 };

--- a/client/src/views/contact_details.js
+++ b/client/src/views/contact_details.js
@@ -3,11 +3,25 @@ var Marionette = require('backbone.marionette');
 module.exports = ContactDetailsView = Marionette.ItemView.extend({
     template: require('../../templates/contact_details.hbs'),
     events: {
-        'click a': 'goBack'
+        'click a.back': 'goBack',
+        'click a.delete': 'deleteContact'
     },
 
     goBack: function(e) {
         e.preventDefault();
+        window.App.controller.home();
+    },
+    deleteContact: function(e) {
+        e.preventDefault();
+        console.log('Deleting contact');
+
+        // this will actually send a DELETE to the server:
+        this.model.destroy({
+          success: function(model, response)  {
+              window.App.data.contacts.remove(this.model);
+          }
+        });
+
         window.App.controller.home();
     }
 });

--- a/client/templates/contact_details.hbs
+++ b/client/templates/contact_details.hbs
@@ -7,4 +7,4 @@
 
 </div>
 
-<a href="#"><< Back</a>
+<a href="#" class="back"><< Back</a> | <a href="#" class="delete">Delete Contact</a>

--- a/controllers/contacts.js
+++ b/controllers/contacts.js
@@ -27,5 +27,16 @@ module.exports = {
     update: function(req, res) {
         console.log(req.body);
         res.json(req.body);
+    },
+    delete: function(req, res) {
+        models.Contact.findOne({ _id: req.params.id }, function(err, contact) {
+            if (err) {
+                res.json({error: 'Contact not found.'});
+            } else {
+                contact.remove(function(err, contact){
+                    res.json(200, {status: 'Success'});
+                })
+            }
+        });
     }
 };


### PR DESCRIPTION
Added delete functionality so that the gulpjs version can send delete requests. I added all the delete functionality from  the original gruntjs version the same way, the only thing I had to change to get it to work properly in this version was in client/src/views/contact_details.js was the remove() and destroy() logic.

```
this.model.destroy({
  success: function(model, response)  {
      window.App.data.contacts.remove(this.model);
  }
});
```
